### PR TITLE
Redesign table so every card is visible and the layout looks polished

### DIFF
--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -6,12 +6,22 @@ interface CardComponentProps {
   style?: React.CSSProperties;
 }
 
+const innerStyle: React.CSSProperties = {
+  width: "100%",
+  height: "100%",
+  display: "block",
+};
+
 const CardComponent: React.FC<CardComponentProps> = ({
   style,
   card,
 }: CardComponentProps) => {
   let c = newCard(card);
-  return c.render(style);
+  return (
+    <div className="game-card" style={style}>
+      {c.render(innerStyle)}
+    </div>
+  );
 };
 
 export default CardComponent;

--- a/src/components/cardImages/cardBack.tsx
+++ b/src/components/cardImages/cardBack.tsx
@@ -5,13 +5,14 @@ interface Props {
 }
 
 const SvgComponent = ({ style }: Props) => (
+  <div className="game-card" style={style}>
   <svg
     xmlns="http://www.w3.org/2000/svg"
     xmlSpace="preserve"
-    width="234"
-    height="333"
+    width="100%"
+    height="100%"
     viewBox="0 0 187.182 266.908"
-    style={style}
+    style={{ display: "block", width: "100%", height: "100%" }}
   >
     <title>{"Red Card Back"}</title>
     <rect
@@ -466,5 +467,6 @@ const SvgComponent = ({ style }: Props) => (
       }}
     />
   </svg>
+  </div>
 );
 export default SvgComponent;

--- a/src/components/deck/deck.tsx
+++ b/src/components/deck/deck.tsx
@@ -1,4 +1,3 @@
-import { Flex } from "antd";
 import React from "react";
 import CardBack from "../cardImages/cardBack";
 
@@ -7,31 +6,67 @@ interface DeckProps {
 }
 
 const Deck: React.FC<DeckProps> = ({ deckNumber }) => {
+  const visibleStack = Math.min(Math.max(deckNumber, 0), 5);
+  const empty = deckNumber === 0;
+
   return (
-    <Flex style={deckStyle} vertical justify="flex-end">
-      {Array.from({ length: deckNumber }).map((_, index) => (
-        <CardBack
-          key={index}
-          style={{ ...cardStyle, left: index * 1, zIndex: index, top: 0 }}
-        />
-      ))}
-    </Flex>
+    <div style={wrapper}>
+      <span className="section-label">Deck</span>
+      <div style={pile}>
+        {empty ? (
+          <div style={emptySlot}>Empty</div>
+        ) : (
+          <>
+            {Array.from({ length: visibleStack }).map((_, index) => (
+              <CardBack
+                key={index}
+                style={{
+                  ...cardStyle,
+                  left: `${index * 2}px`,
+                  top: `${-index * 2}px`,
+                  zIndex: index,
+                }}
+              />
+            ))}
+            <span className="pile-badge">{deckNumber}</span>
+          </>
+        )}
+      </div>
+    </div>
   );
 };
 
-const deckStyle: React.CSSProperties = {
-  position: "relative",
-  width: "100%",
-  height: "100%",
-  flex: 1,
+const wrapper: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: "0.4em",
 };
 
-const remainingCards: React.CSSProperties = {};
+const pile: React.CSSProperties = {
+  position: "relative",
+  width: "6em",
+  aspectRatio: "233 / 333",
+};
 
 const cardStyle: React.CSSProperties = {
   position: "absolute",
   width: "100%",
   height: "100%",
+};
+
+const emptySlot: React.CSSProperties = {
+  width: "100%",
+  height: "100%",
+  borderRadius: "8px",
+  border: "2px dashed rgba(245, 233, 200, 0.45)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "rgba(245, 233, 200, 0.6)",
+  fontSize: "0.85em",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
 };
 
 export default Deck;

--- a/src/components/discardPile/discardPile.tsx
+++ b/src/components/discardPile/discardPile.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Card, CardType } from "../../models/card";
+import { CardType } from "../../models/card";
 import FaceUpCard from "../card/card";
 
 interface DiscardPileProps {
@@ -11,38 +11,90 @@ const DiscardPile: React.FC<DiscardPileProps> = ({
   cards,
   lastCardsPlayed,
 }) => {
+  const baseStackTop = cards.slice(-3);
+  const total = cards.length + lastCardsPlayed.length;
+
   return (
-    <div style={deckStyle}>
-      {cards.map((card, index) => {
-        let style: React.CSSProperties = {
-          ...cardStyle,
-          left: index * 1,
-          zIndex: index,
-        };
-        return <FaceUpCard key={index} style={style} card={card}></FaceUpCard>;
-      })}
-      {lastCardsPlayed.map((card, index) => {
-        let style: React.CSSProperties = {
-          ...cardStyle,
-          left: index * 5 + 20 + cards.length,
-          zIndex: cards.length + index,
-        };
-        return <FaceUpCard key={index} style={style} card={card}></FaceUpCard>;
-      })}
+    <div style={wrapper}>
+      <span className="section-label">Discard</span>
+      <div style={pile}>
+        {total === 0 ? (
+          <div style={emptySlot}>Empty</div>
+        ) : (
+          <>
+            {baseStackTop.map((card, index) => {
+              const style: React.CSSProperties = {
+                ...cardStyle,
+                left: `${index * 2}px`,
+                top: `${-index * 2}px`,
+                zIndex: index,
+              };
+              return (
+                <FaceUpCard
+                  key={`base-${index}`}
+                  style={style}
+                  card={card}
+                />
+              );
+            })}
+
+            {lastCardsPlayed.map((card, index) => {
+              const offset = baseStackTop.length * 2;
+              const style: React.CSSProperties = {
+                ...cardStyle,
+                left: `calc(${offset}px + ${index * 1.4}em)`,
+                top: `${-offset - index * 4}px`,
+                zIndex: 100 + index,
+                boxShadow:
+                  "0 0 0 2px rgba(245, 210, 122, 0.7), 0 10px 22px rgba(0,0,0,0.55)",
+              };
+              return (
+                <FaceUpCard
+                  key={`last-${index}`}
+                  style={style}
+                  card={card}
+                />
+              );
+            })}
+            <span className="pile-badge">{cards.length}</span>
+          </>
+        )}
+      </div>
     </div>
   );
 };
 
-const deckStyle: React.CSSProperties = {
+const wrapper: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: "0.4em",
+};
+
+const pile: React.CSSProperties = {
   position: "relative",
-  width: '100%',
-  height:'100%',
-  flex: 1,
+  width: "6em",
+  aspectRatio: "233 / 333",
 };
 
 const cardStyle: React.CSSProperties = {
   position: "absolute",
-  minWidth: "7em",
+  width: "100%",
+  height: "100%",
+};
+
+const emptySlot: React.CSSProperties = {
+  width: "100%",
+  height: "100%",
+  borderRadius: "8px",
+  border: "2px dashed rgba(245, 233, 200, 0.45)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "rgba(245, 233, 200, 0.6)",
+  fontSize: "0.85em",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
 };
 
 export default DiscardPile;

--- a/src/components/downFacingCardDeck/downFacingCardDeck.tsx
+++ b/src/components/downFacingCardDeck/downFacingCardDeck.tsx
@@ -8,43 +8,52 @@ interface Props {
 }
 
 const DownFacingCardDeck: React.FC<Props> = ({ bestCards, blindCards }) => {
-  // Implement your component logic here
+  const slots = Math.max(blindCards, bestCards, 3);
 
   return (
-    <Flex justify="space-around" style={deckStyle}>
-      {Array.from({ length: blindCards }).map((_, index) => {
-        let style: React.CSSProperties = {
-          ...cardStyle,
-          left: (index - 1) * 4 + "em",
-          zIndex: index,
-        };
+    <Flex justify="center" align="flex-end" gap="0.5em" style={container}>
+      {Array.from({ length: slots }).map((_, index) => {
+        const hasBlind = index < blindCards;
+        const hasBest = index < bestCards;
 
-        return <CardBack key={index} style={style} />;
-      })}
-
-      {Array.from({ length: bestCards }).map((_, index) => {
-        let style: React.CSSProperties = {
-          ...cardStyle,
-          left: ((index - 1) * 4) + 0.5 + "em",
-          zIndex: index,
-        };
-
-        return <CardBack  key={index} style={style} />;
+        return (
+          <div key={index} style={slot}>
+            {hasBlind && <CardBack style={blindStyle} />}
+            {hasBest && <CardBack style={bestStyle} />}
+          </div>
+        );
       })}
     </Flex>
   );
 };
 
-const deckStyle: React.CSSProperties = {
-  position: "relative",
+const container: React.CSSProperties = {
   width: "100%",
   height: "100%",
 };
 
-const cardStyle: React.CSSProperties = {
+const slot: React.CSSProperties = {
+  position: "relative",
+  width: "3em",
+  aspectRatio: "233 / 333",
+};
+
+const blindStyle: React.CSSProperties = {
   position: "absolute",
   width: "100%",
   height: "100%",
+  top: 0,
+  left: 0,
+  zIndex: 1,
+};
+
+const bestStyle: React.CSSProperties = {
+  position: "absolute",
+  width: "100%",
+  height: "100%",
+  top: "-0.6em",
+  left: "0.6em",
+  zIndex: 2,
 };
 
 export default DownFacingCardDeck;

--- a/src/components/myCards/myCards.tsx
+++ b/src/components/myCards/myCards.tsx
@@ -1,18 +1,11 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Card, CardType, newCard } from "../../models/card";
 import FaceUpCard from "../card/card";
 import { selectGameState } from "../../redux/gameState/gameStateSlice";
-import socket from "../../services/socket.io/socket.io";
-import { SocketEvents } from "../../models/socketEvents";
-import { BestCardSelection } from "../../models/bestCardSelection";
-import { selectRoom } from "../../redux/roomState/roomStateSlice";
 import { selectPlayerState } from "../../redux/playerState/playerStateSlice";
 import DownFacingCardDeck from "../downFacingCardDeck/downFacingCardDeck";
-import { Turn } from "../../models/turn";
-import { every, uniq, uniqBy } from "lodash";
-import { Nomination } from "../../models/nomination";
-import { PickUpModel } from "../../models/pickUpModel";
-import { Button, Flex } from "antd";
+import { uniqBy } from "lodash";
+import { Flex } from "antd";
 import Controls from "../controls/controls";
 import useGameStateService from "../../hooks/useGameStateService/useGameStateService";
 import useWindowDimensions from "../../hooks/useWindowDimensions/useWindowDimensions";
@@ -21,15 +14,23 @@ interface MyCardsProps {
   cards: readonly CardType[];
 }
 
+const CARD_HEIGHT_EM = 9.5;
+const CARD_ASPECT = 233 / 333;
+const SIDE_RESERVED_PX = 120;
+
 const MyCards: React.FC<MyCardsProps> = ({ cards }: MyCardsProps) => {
-  let sortedCards = cards
-    .map((c) => newCard(c))
-    .sort((a: Card, b: Card) => a.getNumber() - b.getNumber());
+  let sortedCards = useMemo(
+    () =>
+      cards
+        .map((c) => newCard(c))
+        .sort((a: Card, b: Card) => a.getNumber() - b.getNumber()),
+    [cards]
+  );
 
   const gameState = selectGameState();
   const gameFunctions = useGameStateService();
   const playerState = selectPlayerState();
-  const { height, width } = useWindowDimensions();
+  const { width } = useWindowDimensions();
 
   const [selectedCardIndexes, setSelectedCardIndexes] = useState<number[]>([]);
 
@@ -58,67 +59,114 @@ const MyCards: React.FC<MyCardsProps> = ({ cards }: MyCardsProps) => {
     [gameState?.cardSelectingState, sortedCards]
   );
 
+  const fanLayout = useMemo(() => {
+    const remPx = 16;
+    const cardWidthPx = CARD_HEIGHT_EM * CARD_ASPECT * remPx;
+    const available = Math.max(width - SIDE_RESERVED_PX, 260);
+    const n = sortedCards.length;
+    const fitStep = n > 1 ? (available - cardWidthPx) / (n - 1) : 0;
+    const maxStep = cardWidthPx * 0.55;
+    const minStep = 14;
+    const step = Math.max(minStep, Math.min(maxStep, fitStep));
+    const totalWidth = cardWidthPx + step * Math.max(n - 1, 0);
+    return { cardWidthPx, step, totalWidth };
+  }, [width, sortedCards.length]);
+
   if (!playerState || !playerState.me) {
     return null;
   }
 
+  const statusMessage = gameFunctions.getStatusMessage(playerState.me);
+
   return (
-    <Flex vertical style={{ height: "100%", width: '100%', textAlign: 'center' }}>
-      <div>{gameFunctions.getStatusMessage(playerState.me)}</div>
-      <Flex vertical justify="center" align="center" style={container}>
+    <Flex vertical align="center" style={{ height: "100%", width: "100%" }}>
+      {statusMessage && <div className="hand-status">{statusMessage}</div>}
+
+      <Flex
+        vertical
+        align="center"
+        justify="flex-end"
+        style={{ width: "100%", flex: 1 }}
+      >
         <Controls
           bestCards={playerState.me.bestCards}
           selectedCards={selectedCardIndexes.map((index) => sortedCards[index])}
           onConfirm={() => setSelectedCardIndexes([])}
         />
-        <Flex style={deckStyle} flex={2} vertical>
-          {sortedCards.map((card, index) => {
-            let isSelected = selectedCardIndexes.includes(index);
-            let style: React.CSSProperties = {
-              ...cardStyle,
-              left: `calc(50% + ${((index) - ((sortedCards.length + 1) / 2 + (height / 400))) * 1.5}em)`,
-              zIndex: index,
-              top: isSelected ? "10px" : "20px",
-            };
 
-            return (
-              <div style={style} key={index} onClick={(e) => selectCard(index)} >
-                <FaceUpCard card={card}></FaceUpCard>
-              </div>
-            );
-          })}
-        </Flex>
-        <Flex style={blindCardsContainer} flex={1}>
+        <Flex justify="center" style={blindCardsContainer}>
           <DownFacingCardDeck
             bestCards={playerState?.me?.bestCards?.length || 0}
             blindCards={playerState?.me?.blindCards || 0}
           />
         </Flex>
+
+        <div
+          style={{
+            ...handContainer,
+            height: `${CARD_HEIGHT_EM + 1.5}em`,
+          }}
+        >
+          <div
+            style={{
+              position: "relative",
+              width: `${fanLayout.totalWidth}px`,
+              maxWidth: "100%",
+              height: "100%",
+              margin: "0 auto",
+            }}
+          >
+            {sortedCards.map((card, index) => {
+              const isSelected = selectedCardIndexes.includes(index);
+              const cardStyle: React.CSSProperties = {
+                position: "absolute",
+                width: `${fanLayout.cardWidthPx}px`,
+                aspectRatio: `${CARD_ASPECT}`,
+                left: `${index * fanLayout.step}px`,
+                bottom: isSelected ? "1.2em" : "0",
+                zIndex: index + 1,
+              };
+
+              return (
+                <div
+                  key={index}
+                  style={cardStyle}
+                  onClick={() => selectCard(index)}
+                  className={`game-card-slot${isSelected ? " selected" : ""}`}
+                >
+                  <FaceUpCard
+                    card={card}
+                    style={{
+                      width: "100%",
+                      height: "100%",
+                      borderRadius: "8px",
+                      cursor: "pointer",
+                      boxShadow: isSelected
+                        ? "0 0 0 2px #f5d27a, 0 12px 24px rgba(0,0,0,0.55)"
+                        : undefined,
+                    }}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
       </Flex>
     </Flex>
   );
 };
 
-const container: React.CSSProperties = {
-  height: "100%",
-
-};
-
-const deckStyle: React.CSSProperties = {
-  position: "relative",
-  height: "100%",
-  width: "100%",
-  marginBottom: '2em'
-};
-
 const blindCardsContainer: React.CSSProperties = {
   width: "100%",
-  height: "100%",
+  marginBottom: "0.6em",
 };
 
-const cardStyle: React.CSSProperties = {
-  position: "absolute",
-  height: "100%",
+const handContainer: React.CSSProperties = {
+  width: "100%",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "flex-end",
+  padding: "0 1em",
 };
 
 export default MyCards;

--- a/src/components/opponentDeck/opponentDeck.tsx
+++ b/src/components/opponentDeck/opponentDeck.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import CardBack from "../cardImages/cardBack";
 import DownFacingCardDeck from "../downFacingCardDeck/downFacingCardDeck";
 import { Flex } from "antd";
@@ -10,73 +10,95 @@ interface OpponentDeckProps {
   player: OtherPlayer;
 }
 
+const CARD_HEIGHT_EM = 4.8;
+const CARD_ASPECT = 233 / 333;
+
 const OpponentDeck: React.FC<OpponentDeckProps> = ({ player }) => {
   const gameState = selectGameState();
   const gameFunctions = useGameStateService();
 
+  const isPlaying = gameState.gameStarted && gameFunctions.isPlayerTurn(player);
+
   let status: string;
   if (gameState.gameStarted) {
-    status = gameFunctions.isPlayerTurn(player) ? "Playing" : "";
+    status = isPlaying ? "Playing" : "";
   } else {
     status = player.isReady ? "Ready" : "Not Ready";
   }
 
+  const fan = useMemo(() => {
+    const remPx = 16;
+    const cardWidthPx = CARD_HEIGHT_EM * CARD_ASPECT * remPx;
+    const n = player.cardsHeld;
+    const maxFanPx = 11 * remPx;
+    const maxStep = cardWidthPx * 0.55;
+    const minStep = 6;
+    const fitStep = n > 1 ? (maxFanPx - cardWidthPx) / (n - 1) : 0;
+    const step = Math.max(minStep, Math.min(maxStep, fitStep));
+    const totalWidth = cardWidthPx + step * Math.max(n - 1, 0);
+    return { cardWidthPx, step, totalWidth };
+  }, [player.cardsHeld]);
+
   return (
     <div style={container}>
-      <h3 style={headerStyle}>
-        {player.name} {!!status ? `(${status})` : ""}
-      </h3>
-      <Flex style={downCardContainer} flex={1}>
+      <span className={`player-plate${isPlaying ? " active" : ""}`}>
+        <span>{player.name}</span>
+        {!!status && <span className="plate-status">{status}</span>}
+      </span>
+
+      <Flex justify="center" style={downCardContainer}>
         <DownFacingCardDeck
           bestCards={player.bestCards}
           blindCards={player.blindCards}
         />
       </Flex>
-      <Flex style={deckStyle} flex={2}>
-        {Array.from({ length: player.cardsHeld }).map((_, index) => {
-          let style: React.CSSProperties = {
-            ...cardStyle,
-            left: (index + 1) * 0.7 - (player.cardsHeld / 2) * 0.7 + "em",
-            zIndex: index,
-          };
 
-          return <CardBack key={index} style={style} />;
-        })}
-      </Flex>
+      <div style={handContainer}>
+        <div
+          style={{
+            position: "relative",
+            width: `${fan.totalWidth}px`,
+            height: `${CARD_HEIGHT_EM}em`,
+            maxWidth: "100%",
+          }}
+        >
+          {Array.from({ length: player.cardsHeld }).map((_, index) => {
+            const cardStyle: React.CSSProperties = {
+              position: "absolute",
+              width: `${fan.cardWidthPx}px`,
+              aspectRatio: `${CARD_ASPECT}`,
+              left: `${index * fan.step}px`,
+              top: 0,
+              borderRadius: "6px",
+            };
+            return <CardBack key={index} style={cardStyle} />;
+          })}
+        </div>
+      </div>
     </div>
   );
-};
-
-const headerStyle: React.CSSProperties = {
-  marginTop: "0.3em",
-  marginBottom: "0.3em",
-  width: "100%",
 };
 
 const container: React.CSSProperties = {
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
-  flexBasis: "min-content",
-  width: "100%",
-  textAlign: "center",
+  gap: "0.4em",
+  flex: 1,
+  minWidth: "10em",
+  padding: "0.4em",
 };
 
 const downCardContainer: React.CSSProperties = {
   width: "100%",
-  height: "100%",
+  height: "5.5em",
 };
 
-const deckStyle: React.CSSProperties = {
-  position: "relative",
-  height: "100%",
+const handContainer: React.CSSProperties = {
   width: "100%",
-};
-
-const cardStyle: React.CSSProperties = {
-  position: "absolute",
-  width: "100%",
-  height: "100%",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "flex-start",
 };
 
 export default OpponentDeck;

--- a/src/components/playArea/playArea.tsx
+++ b/src/components/playArea/playArea.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import DiscardPile from "../discardPile/discardPile";
 import Deck from "../deck/deck";
 import { selectGameState } from "../../redux/gameState/gameStateSlice";
-import { Five, Suit } from "../../models/card";
 
 interface Props {
   style: React.CSSProperties;
@@ -13,24 +12,35 @@ const PlayArea: React.FC<Props> = ({ style }) => {
   const gameState = selectGameState();
 
   return (
-    <Flex vertical justify="center" align="center" flex={1}>
-      <Flex style={{ ...container, ...style }} justify="space-evenly">
-        <DiscardPile
-          cards={gameState.bottomDiscardPile}
-          lastCardsPlayed={gameState.lastCardsPlayed}
-        />
-        <Deck deckNumber={gameState.pickupDeckNumber} />
-      </Flex>
-      <span>Remaining cards: {gameState.pickupDeckNumber}</span>
+    <Flex vertical justify="center" align="center" style={{ width: "100%" }}>
+      <div style={{ ...table, ...style }}>
+        <Flex
+          justify="space-evenly"
+          align="center"
+          style={{ width: "100%", height: "100%" }}
+        >
+          <DiscardPile
+            cards={gameState.bottomDiscardPile}
+            lastCardsPlayed={gameState.lastCardsPlayed}
+          />
+          <Deck deckNumber={gameState.pickupDeckNumber} />
+        </Flex>
+      </div>
     </Flex>
   );
 };
 
-const container: React.CSSProperties = {
+const table: React.CSSProperties = {
   display: "flex",
-  width: '100%',
-  height: '100%',
-  maxWidth:'30em'
+  width: "min(36em, 92%)",
+  minHeight: "12em",
+  padding: "1.4em 1.2em",
+  borderRadius: "20px",
+  background:
+    "radial-gradient(ellipse at center, rgba(255,255,255,0.08) 0%, rgba(0,0,0,0.35) 100%)",
+  border: "1px solid rgba(245, 210, 122, 0.4)",
+  boxShadow:
+    "0 0 0 4px rgba(0,0,0,0.25) inset, 0 8px 24px rgba(0,0,0,0.35)",
 };
 
 export default PlayArea;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
+html,
+body,
+#root {
+  height: 100%;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -5,9 +11,143 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: #0b3d2e;
+  color: #f5e9c8;
 }
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+/* ---- Game table ---- */
+.game-table {
+  position: relative;
+  background-size: cover;
+  background-position: center;
+  box-shadow: inset 0 0 120px rgba(0, 0, 0, 0.6);
+  color: #f5e9c8;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.7);
+}
+
+.game-table::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    ellipse at center,
+    rgba(255, 255, 255, 0.06) 0%,
+    rgba(0, 0, 0, 0.55) 95%
+  );
+  z-index: 0;
+}
+
+.game-table > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* ---- Card frame (applied to every face-up / face-down card) ---- */
+.game-card {
+  border-radius: 8px;
+  background: #fff;
+  overflow: hidden;
+  box-shadow:
+    0 4px 10px rgba(0, 0, 0, 0.45),
+    0 1px 2px rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, top 0.18s ease;
+  user-select: none;
+}
+
+.game-card.clickable {
+  cursor: pointer;
+}
+
+.game-card.clickable:hover {
+  box-shadow:
+    0 8px 18px rgba(0, 0, 0, 0.55),
+    0 2px 4px rgba(0, 0, 0, 0.35);
+}
+
+.game-card.selected {
+  box-shadow:
+    0 0 0 2px #f5d27a,
+    0 10px 22px rgba(0, 0, 0, 0.55);
+}
+
+.game-card svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* ---- Player name plate ---- */
+.player-plate {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.25em 0.9em;
+  margin: 0;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(245, 210, 122, 0.35);
+  font-size: 0.95em;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #f5e9c8;
+}
+
+.player-plate.active {
+  background: linear-gradient(135deg, rgba(245, 210, 122, 0.35), rgba(245, 210, 122, 0.15));
+  border-color: #f5d27a;
+  box-shadow: 0 0 12px rgba(245, 210, 122, 0.55);
+  color: #fff;
+}
+
+.player-plate .plate-status {
+  font-size: 0.8em;
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+/* ---- Pile count badge ---- */
+.pile-badge {
+  position: absolute;
+  bottom: -0.5em;
+  right: -0.5em;
+  min-width: 1.8em;
+  height: 1.8em;
+  padding: 0 0.4em;
+  border-radius: 999px;
+  background: #f5d27a;
+  color: #1c1c1c;
+  font-weight: 700;
+  font-size: 0.85em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid rgba(0, 0, 0, 0.35);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  z-index: 999;
+}
+
+/* ---- Section labels ---- */
+.section-label {
+  font-size: 0.85em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+/* ---- Status banner above hand ---- */
+.hand-status {
+  display: inline-block;
+  padding: 0.25em 1em;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  font-weight: 500;
+  margin-bottom: 0.4em;
 }

--- a/src/pages/room/gameRoom.tsx
+++ b/src/pages/room/gameRoom.tsx
@@ -228,24 +228,30 @@ const GameRoom: React.FC<GameRoomProps> = ({}) => {
       <Sider width={"3em"}>
         <MyHeader roomName={roomModel.roomName} />
       </Sider>
-      <Content style={content}>
+      <Content className="game-table" style={content}>
         <Flex vertical style={{ height: "100%" }}>
           <Flex style={{ height: "100%" }}>
             <Flex
               flex={1}
               vertical
               justify="space-between"
-              style={{ height: "100%" }}
+              style={{ height: "100%", padding: "0.6em 0.8em" }}
             >
               {gameState?.gameStarted && playerState?.hand && (
                 <>
-                  <Flex style={section} justify="space-evenly" flex={1}>
+                  <Flex
+                    style={opponentsRow}
+                    justify="space-evenly"
+                    align="flex-start"
+                    wrap="wrap"
+                    gap="1em"
+                  >
                     {playerState.otherPlayers.map((player, index) => (
                       <OpponentDeck player={player} key={index} />
                     ))}
                   </Flex>
 
-                  <Flex justify="center" style={section} flex={1}>
+                  <Flex justify="center" align="center" style={section} flex={1}>
                     <PlayArea style={{}} />
                   </Flex>
                   <Flex justify="center" style={section} flex={2}>
@@ -338,13 +344,20 @@ const GameRoom: React.FC<GameRoomProps> = ({}) => {
 const content: React.CSSProperties = {
   backgroundImage: "url('/images/green-felt.jpg')",
   backgroundSize: "cover",
-  color: "#EEE",
-  textShadow: "1px 1px 1px #000",
+  backgroundPosition: "center",
+  color: "#f5e9c8",
+  textShadow: "1px 1px 2px rgba(0, 0, 0, 0.7)",
 };
 
 const section: React.CSSProperties = {
   flex: 1,
   width: "100%",
+};
+
+const opponentsRow: React.CSSProperties = {
+  flex: 1,
+  width: "100%",
+  paddingTop: "0.6em",
 };
 
 export default GameRoom;


### PR DESCRIPTION
- Fan the player's hand with dynamic spacing (clamped between min/max
  step) so all cards stay visible regardless of count, and lift the
  selected card with a gold highlight.
- Apply a unified .game-card frame (rounded corners, soft shadow,
  border) to every face-up and face-down card.
- Render opponent hands as compact, evenly-spaced fans with active
  player name plates that glow when it's their turn.
- Show deck and discard piles as fixed-size stacks with a count badge
  and a dashed empty-slot placeholder; the last cards played are now
  highlighted on top of the discard pile.
- Lay blind/best cards in tidy slots so each is individually readable.
- Wrap the play area in a felt-toned card with a gold border and add
  a vignette overlay on the table background.